### PR TITLE
Request header parsing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ NAME		=	webserv
 
 CC			=	c++
 
-CFLAGS		=	#-Wall -Werror -Wextra
+CFLAGS		=	-Wall -Werror -Wextra
 
 # directories
 SRC_DIR		=	src/

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ NAME		=	webserv
 
 CC			=	c++
 
-CFLAGS		=	-Wall -Werror -Wextra -std=c++98
+CFLAGS		=	#-Wall -Werror -Wextra
 
 # directories
 SRC_DIR		=	src/

--- a/include/HttpRequestParser.hpp
+++ b/include/HttpRequestParser.hpp
@@ -5,6 +5,7 @@
 #include <string>
 #include <iostream>
 #include <sstream>
+#include <map>
 
 class HttpRequestParser
 {
@@ -12,13 +13,13 @@ class HttpRequestParser
 		HttpRequestParser();
 		~HttpRequestParser();
 
-		HttpRequest					parseHttpRequest(std::string request);
-		void						parseRequestLine(std::string &requestLine, std::string &method, std::string &uri, std::string &version);
-		std::string					parseMethod(std::string &requestLine);
-		const std::string			parseVersion(std::string &requestLine);
-		const std::string			parseUri(std::string &requestLine);
-		const std::string			parseHost();
-		const std::string			parseBody();
-		int							parseContentLength();
-		int							compareMethod(std::string method, std::string &requestLine);
+		HttpRequest									parseHttpRequest(std::string request);
+		void										parseRequestLine(std::string &requestLine, std::string &method, std::string &uri, std::string &version);
+		std::string									parseMethod(std::string &requestLine);
+		const std::string							parseVersion(std::string &requestLine);
+		const std::string							parseUri(std::string &requestLine);
+		std::string									parseHost(std::map<std::string, std::string> &headers);
+		const std::map<std::string, std::string>	parseHeaders(const std::string &request, std::map<std::string, std::string> &headers);
+		const std::string							parseBody();
+		int											compareMethod(std::string method, std::string &requestLine);
 };

--- a/include/HttpRequestParser.hpp
+++ b/include/HttpRequestParser.hpp
@@ -18,8 +18,10 @@ class HttpRequestParser
 		std::string									parseMethod(std::string &requestLine);
 		const std::string							parseVersion(std::string &requestLine);
 		const std::string							parseUri(std::string &requestLine);
-		std::string									parseHost(std::map<std::string, std::string> &headers);
+		// std::string									parseHost(std::map<std::string, std::string> &headers, std::string &host);
+		std::string									getHeaderValue(std::map<std::string, std::string> &headers, std::string toFind);
 		const std::map<std::string, std::string>	parseHeaders(const std::string &request, std::map<std::string, std::string> &headers);
-		const std::string							parseBody();
+		bool										findBody(std::string newLine, bool &bodyFound);
+		const std::string							parseBody(std::string newLine, std::string &body);
 		int											compareMethod(std::string method, std::string &requestLine);
 };

--- a/include/HttpRequestParser.hpp
+++ b/include/HttpRequestParser.hpp
@@ -13,15 +13,14 @@ class HttpRequestParser
 		HttpRequestParser();
 		~HttpRequestParser();
 
-		HttpRequest									parseHttpRequest(std::string request);
-		void										parseRequestLine(std::string &requestLine, std::string &method, std::string &uri, std::string &version);
-		std::string									parseMethod(std::string &requestLine);
-		const std::string							parseVersion(std::string &requestLine);
-		const std::string							parseUri(std::string &requestLine);
-		// std::string									parseHost(std::map<std::string, std::string> &headers, std::string &host);
-		std::string									getHeaderValue(std::map<std::string, std::string> &headers, std::string toFind);
-		const std::map<std::string, std::string>	parseHeaders(const std::string &request, std::map<std::string, std::string> &headers);
-		bool										findBody(std::string newLine, bool &bodyFound);
-		const std::string							parseBody(std::string newLine, std::string &body);
-		int											compareMethod(std::string method, std::string &requestLine);
+		HttpRequest				parseHttpRequest(std::string request);
+		void					parseRequestLine(std::string &requestLine, std::string &method, std::string &uri, std::string &version);
+		const std::string		parseMethod(std::string &requestLine);
+		const std::string		parseVersion(std::string &requestLine);
+		const std::string		parseUri(std::string &requestLine);
+		const std::string		getHeaderValue(std::map<std::string, std::string> &headers, std::string toFind);
+		void					parseHeaders(const std::string &request, std::map<std::string, std::string> &headers);
+		void					findBody(std::string newLine, bool &bodyFound);
+		void					parseBody(std::string newLine, std::string &body);
+		int						compareMethod(std::string method, std::string &requestLine);
 };

--- a/src/HttpRequestParser.cpp
+++ b/src/HttpRequestParser.cpp
@@ -60,7 +60,7 @@ void HttpRequestParser::parseRequestLine(std::string &requestLine, std::string &
 		version = parseVersion(requestLine);
 }
 
-std::string HttpRequestParser::parseMethod(std::string &requestLine)
+const std::string HttpRequestParser::parseMethod(std::string &requestLine)
 {
 	std::string method;
 	if (compareMethod("GET ", requestLine) == 0)
@@ -104,7 +104,7 @@ const std::string HttpRequestParser::parseUri(std::string &requestLine)
 	return uri;
 }
 
-std::string HttpRequestParser::getHeaderValue(std::map<std::string, std::string> &headers, std::string toFind)
+const std::string HttpRequestParser::getHeaderValue(std::map<std::string, std::string> &headers, std::string toFind)
 {
 	std::map<std::string, std::string>::iterator it;
 	std::string ret = "";
@@ -118,7 +118,7 @@ std::string HttpRequestParser::getHeaderValue(std::map<std::string, std::string>
 	return ret;
 }
 
-const std::map<std::string, std::string> HttpRequestParser::parseHeaders(const std::string &line, std::map<std::string, std::string> &headers)
+void HttpRequestParser::parseHeaders(const std::string &line, std::map<std::string, std::string> &headers)
 {
 	size_t pos = line.find(':');
 	if (pos != std::string::npos)
@@ -129,23 +129,17 @@ const std::map<std::string, std::string> HttpRequestParser::parseHeaders(const s
 		if (headers[key].empty())
 			headers[key] = value;
 	}
-	return headers;
+
 }
 
-bool HttpRequestParser::findBody(std::string newLine, bool &bodyFound)
+void HttpRequestParser::findBody(std::string newLine, bool &bodyFound)
 {
 	if (bodyFound == false && newLine.compare("\r\n"))
-	{
 		bodyFound = true;
-		return true;
-	}
-	return false;
 }
 
-const std::string HttpRequestParser::parseBody(std::string newLine, std::string &body)
+void HttpRequestParser::parseBody(std::string newLine, std::string &body)
 {
 	body += newLine;
-
-	return NULL;
 }
 

--- a/src/HttpRequestParser.cpp
+++ b/src/HttpRequestParser.cpp
@@ -36,15 +36,12 @@ HttpRequest HttpRequestParser::parseHttpRequest(std::string requestInput)
 			parseHeaders(newLine, headers);
 		else if (headersComplete == true && contentLength.empty())
 			contentLength = getHeaderValue(headers, "Content-Length");
-		//TODO: add getting content length from headers properly.
-		//for GET method content length & body is not needed, but needs to be handled for request constructor
 		else if (headersComplete == true && bodyFound == false)
 			findBody(newLine, bodyFound);
 		else if (bodyFound == true)
 			parseBody(newLine, body);
 	}
 	host = getHeaderValue(headers, "Host");
-	//TODO body.length() should be contentLength as int, if GET method length is 0?
 	HttpRequest request(method, version, uri, host, body, body.length());
 	return request;
 }
@@ -129,7 +126,6 @@ const std::map<std::string, std::string> HttpRequestParser::parseHeaders(const s
 		std::string key = line.substr(0, pos);
 		std::string value = line.substr(pos + 1);
 
-		//TODO: figuring out if we should handle overwriting the pair for a preexisting key
 		if (headers[key].empty())
 			headers[key] = value;
 	}

--- a/src/HttpRequestParser.cpp
+++ b/src/HttpRequestParser.cpp
@@ -34,12 +34,17 @@ HttpRequest HttpRequestParser::parseHttpRequest(std::string requestInput)
 		}
 		else if (headersComplete == false)
 			parseHeaders(newLine, headers);
-		else if (headersComplete == true && contentLength.empty())
-			contentLength = getHeaderValue(headers, "Content-Length");
-		else if (headersComplete == true && bodyFound == false)
-			findBody(newLine, bodyFound);
-		else if (bodyFound == true)
-			parseBody(newLine, body);
+		if (method.compare("POST") == 0)
+		{
+			if (headersComplete == true && contentLength.empty())
+				contentLength = getHeaderValue(headers, "Content-Length");
+			else if (headersComplete == true && bodyFound == false)
+				findBody(newLine, bodyFound);
+			else if (bodyFound == true)
+				parseBody(newLine, body);
+		}
+		if (bodyComplete == true)
+			break;
 	}
 	host = getHeaderValue(headers, "Host");
 	HttpRequest request(method, version, uri, host, body, body.length());
@@ -140,6 +145,8 @@ void HttpRequestParser::findBody(std::string newLine, bool &bodyFound)
 
 void HttpRequestParser::parseBody(std::string newLine, std::string &body)
 {
+	//TODO: here to check if the body.length == content-length
+	//if yes, trigger flag, if not add newLine to body
 	body += newLine;
 }
 


### PR DESCRIPTION
Added parsing for the headers and technically also for the body, need to make more tests to confirm that the body parsing fully works as well. Next step would be adding enums for the methods, adding more validation (state for the request for example), testing with post -method and using content length from the parsed headers. 