### PR TITLE
Cgi file validation

### DIFF
--- a/include/FileHandler.hpp
+++ b/include/FileHandler.hpp
@@ -10,4 +10,5 @@ class FileHandler
 		static std::string getFileContent(std::string filename);
 		static std::string getErrorFileContent(unsigned int status);
 		static std::string getFileResource(std::string path);
+		static std::string getFilePath(std::string relativePath);
 };

--- a/include/HttpRequestHandler.hpp
+++ b/include/HttpRequestHandler.hpp
@@ -4,10 +4,15 @@
 #include "Exceptions.hpp"
 #include "HttpRequest.hpp"
 #include "HttpResponse.hpp"
-
+#include "ExceptionManager.hpp"
+#include "FileHandler.hpp"
 
 class HttpRequestHandler
 {
+	private:
+		bool 	findCgi(std::string uri);
+		bool	validateCgi(std::string uri);
+		
 	public:
 		HttpRequestHandler();
 		~HttpRequestHandler();

--- a/src/FileHandler.cpp
+++ b/src/FileHandler.cpp
@@ -1,7 +1,7 @@
 #include "../include/FileHandler.hpp"
 #include "../include/WebServer.hpp"
 
-static std::string getFilePath(std::string relativePath)
+std::string FileHandler::getFilePath(std::string relativePath)
 {
 	char file_path[MESSAGE_BUFFER];
 	getcwd(file_path, MESSAGE_BUFFER);

--- a/src/HttpRequestHandler.cpp
+++ b/src/HttpRequestHandler.cpp
@@ -1,12 +1,18 @@
 #include "HttpRequestHandler.hpp"
 #include "FileHandler.hpp"
-#include "ExceptionManager.hpp"
 
 HttpResponse HttpRequestHandler::handleRequest(HttpRequest input)
 {
+	bool cgiFound = false;
+	cgiFound = findCgi(input.getUri());
+
 	switch (input.getMethod())
 	{
 		case HttpRequest::METHOD::GET:
+			if (cgiFound == true)
+			{
+				std::cout << "here we would go to execute the script" << std::endl;
+			}
 			return HttpResponse(std::pair<unsigned int, std::string>(200, "OK"), input.getUri());
 			break;
 
@@ -23,6 +29,31 @@ HttpResponse HttpRequestHandler::handleRequest(HttpRequest input)
 			break;
 	}
 	return HttpResponse(ExceptionManager::getErrorStatus(InternalException("Something went wrong")), "");
+}
+
+bool HttpRequestHandler::findCgi(std::string uri)
+{
+	size_t found = uri.find("/bin-cgi");
+	if (found != std::string::npos)
+		return false;
+	return validateCgi(uri);
+}
+
+bool HttpRequestHandler::validateCgi(std::string uri)
+{
+	std::string suffix = ".py";
+	std::string fullPath = FileHandler::getFilePath(uri);
+
+	if (access(fullPath.c_str(), F_OK) == 0)
+	{
+		std::cout << "found access to the correct folder" << std::endl;
+		int pos = fullPath.find(".py");
+		std::string extension = fullPath.substr(pos, fullPath.length());
+		if (extension.compare(suffix) == 0)
+			return true;
+	}
+	throw BadRequestException("Bad CGI request");
+	return false;
 }
 
 HttpRequestHandler::HttpRequestHandler()

--- a/src/HttpRequestHandler.cpp
+++ b/src/HttpRequestHandler.cpp
@@ -5,14 +5,11 @@ HttpResponse HttpRequestHandler::handleRequest(HttpRequest input)
 {
 	bool cgiFound = false;
 	cgiFound = findCgi(input.getUri());
-
 	switch (input.getMethod())
 	{
 		case HttpRequest::METHOD::GET:
 			if (cgiFound == true)
-			{
 				std::cout << "here we would go to execute the script" << std::endl;
-			}
 			return HttpResponse(std::pair<unsigned int, std::string>(200, "OK"), input.getUri());
 			break;
 
@@ -33,10 +30,13 @@ HttpResponse HttpRequestHandler::handleRequest(HttpRequest input)
 
 bool HttpRequestHandler::findCgi(std::string uri)
 {
-	size_t found = uri.find("/bin-cgi");
+	size_t found = uri.find("/cgi_bin");
 	if (found != std::string::npos)
-		return false;
-	return validateCgi(uri);
+	{
+		bool ret = validateCgi(uri);
+		return ret;
+	}
+	return false;
 }
 
 bool HttpRequestHandler::validateCgi(std::string uri)
@@ -46,8 +46,7 @@ bool HttpRequestHandler::validateCgi(std::string uri)
 
 	if (access(fullPath.c_str(), F_OK) == 0)
 	{
-		std::cout << "found access to the correct folder" << std::endl;
-		int pos = fullPath.find(".py");
+		int pos = fullPath.find(suffix);
 		std::string extension = fullPath.substr(pos, fullPath.length());
 		if (extension.compare(suffix) == 0)
 			return true;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -140,30 +140,30 @@ void printVector(const std::vector<std::string>* vecPtr)
 	}
 }
 
-void dansTestFunc()
-{
-	ConfigParser parser;
-	parser.parseConfig("config/default.conf");
+// void dansTestFunc()
+// {
+// 	ConfigParser parser;
+// 	parser.parseConfig("config/default.conf");
 
-	// Access the servers
-	const std::vector<std::shared_ptr<Server>>& servers = parser.getServers();
-	for (std::vector<std::shared_ptr<Server>>::const_iterator it = servers.begin(); it != servers.end(); ++it) {
-		std::shared_ptr<Server> server = *it;
-		if (server)
-		{
-			std::cout << "Methods: ";
-			printVector(server->getLocationValue("/", "method"));
-			printVector(server->getLocationValue("/tmp", "method"));
-			printVector(server->getLocationValue("/cgi-bin", "directory"));
-		}
-	}
-}
+// 	// Access the servers
+// 	const std::vector<std::shared_ptr<Server>>& servers = parser.getServers();
+// 	for (std::vector<std::shared_ptr<Server>>::const_iterator it = servers.begin(); it != servers.end(); ++it) {
+// 		std::shared_ptr<Server> server = *it;
+// 		if (server)
+// 		{
+// 			std::cout << "Methods: ";
+// 			printVector(server->getLocationValue("/", "method"));
+// 			printVector(server->getLocationValue("/tmp", "method"));
+// 			printVector(server->getLocationValue("/cgi-bin", "directory"));
+// 		}
+// 	}
+// }
 
 int main(int argc, char **argv)
 {
 	if (argc != 2 || !argv[1])
 	{
-		dansTestFunc();
+		// dansTestFunc();
 		return 0;
 	}
 


### PR DESCRIPTION
Detects if the client is looking to run a cgi script, checks if the path is valid, we have access etc and prints out "we would run the script" in the  request handler switch case if everything is correct. 

One inconsistency is still there with the error messages thrown - if the cgi_bin portion is wrong it gives method not allowed 404 exception, but in every other case it gives 400 bad request. My brain is fried for today but I can look into it tomorrow, I'm sure its a minor fix. 

Also made the file handlers private function find path public, since it was handy to use in the validation as well. 

Now cgi scripts can be tested by 127.0.0.1:8000/public_www/cgi_bin/hello_world.py